### PR TITLE
Whisk

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -66,7 +66,7 @@ def test_preprocessing_multiprocess(data_dir):
 
 def test_preprocessing_minimal(data_dir):
     """
-    This test is checking to make sure preprocessing does not remove tokens which the user doe not
+    This test is checking to make sure preprocessing does not remove tokens which the user does not
     specify should be removed.
     """
     texts_path = data_dir+"/sample_texts/unprepr_docs.txt"
@@ -87,9 +87,6 @@ def test_preprocessing_minimal(data_dir):
     assert len(raw_word_lens) == len(preprocessed_word_lens)
     for i in range(len(preprocessed_word_lens)):
         assert raw_word_lens[i] == preprocessed_word_lens[i]
-
-    dataset.save(data_dir+"/sample_texts/")
-    dataset.load_custom_dataset_from_folder(data_dir + "/sample_texts")
 
 
 def test_load_20ng():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -54,11 +54,35 @@ def test_preprocessing_english_stops_split(data_dir):
 def test_preprocessing_multiprocess(data_dir):
     texts_path = data_dir+"/sample_texts/unprepr_docs.txt"
     p = Preprocessing(vocabulary=None, max_features=None, remove_punctuation=True,
-                      lemmatize=False,  num_processes=10, split=False,
+                      lemmatize=False, split=False,
                       min_chars=2, min_words_docs=1)
     dataset = p.preprocess_dataset(
         documents_path=texts_path,
     )
+
+    dataset.save(data_dir+"/sample_texts/")
+    dataset.load_custom_dataset_from_folder(data_dir + "/sample_texts")
+
+
+def test_preprocessing_nothing(data_dir):
+    texts_path = data_dir+"/sample_texts/unprepr_docs.txt"
+    p = Preprocessing(vocabulary=None, max_features=None, remove_punctuation=False,
+                      remove_numbers = False,
+                      lemmatize=False, split=False,
+                      min_chars=1, min_words_docs=0)
+    
+    unprocessed = [d.strip() for d in open(texts_path, "r").readlines() if len(d.strip()) > 0]
+    lens = [len(d.split()) for d in unprocessed]
+
+    dataset = p.preprocess_dataset(
+        documents_path=texts_path,
+    )
+    print(dataset.get_corpus())
+    lens_pros = [len(d) for d in dataset.get_corpus()]
+    print(list(zip(lens,lens_pros)))
+    assert len(lens) == len(lens_pros)
+    for i in range(len(lens_pros)):
+        assert lens[i] == lens_pros[i]
 
     dataset.save(data_dir+"/sample_texts/")
     dataset.load_custom_dataset_from_folder(data_dir + "/sample_texts")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -64,7 +64,11 @@ def test_preprocessing_multiprocess(data_dir):
     dataset.load_custom_dataset_from_folder(data_dir + "/sample_texts")
 
 
-def test_preprocessing_nothing(data_dir):
+def test_preprocessing_minimal(data_dir):
+    """
+    This test is checking to make sure preprocessing does not remove tokens which the user doe not
+    specify should be removed.
+    """
     texts_path = data_dir+"/sample_texts/unprepr_docs.txt"
     p = Preprocessing(vocabulary=None, max_features=None, remove_punctuation=False,
                       remove_numbers = False,
@@ -72,17 +76,17 @@ def test_preprocessing_nothing(data_dir):
                       min_chars=1, min_words_docs=0)
     
     unprocessed = [d.strip() for d in open(texts_path, "r").readlines() if len(d.strip()) > 0]
-    lens = [len(d.split()) for d in unprocessed]
+    raw_word_lens = [len(d.split()) for d in unprocessed]
 
     dataset = p.preprocess_dataset(
         documents_path=texts_path,
     )
     print(dataset.get_corpus())
-    lens_pros = [len(d) for d in dataset.get_corpus()]
-    print(list(zip(lens,lens_pros)))
-    assert len(lens) == len(lens_pros)
-    for i in range(len(lens_pros)):
-        assert lens[i] == lens_pros[i]
+    preprocessed_word_lens = [len(d) for d in dataset.get_corpus()]
+    print(list(zip(raw_word_lens,preprocessed_word_lens)))
+    assert len(raw_word_lens) == len(preprocessed_word_lens)
+    for i in range(len(preprocessed_word_lens)):
+        assert raw_word_lens[i] == preprocessed_word_lens[i]
 
     dataset.save(data_dir+"/sample_texts/")
     dataset.load_custom_dataset_from_folder(data_dir + "/sample_texts")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -54,7 +54,7 @@ def test_preprocessing_english_stops_split(data_dir):
 def test_preprocessing_multiprocess(data_dir):
     texts_path = data_dir+"/sample_texts/unprepr_docs.txt"
     p = Preprocessing(vocabulary=None, max_features=None, remove_punctuation=True,
-                      lemmatize=False, split=False,
+                      lemmatize=False, num_processes=10, split=False,
                       min_chars=2, min_words_docs=1)
     dataset = p.preprocess_dataset(
         documents_path=texts_path,


### PR DESCRIPTION
# Description
Addressed issue #115, where punctuation and the tokens attached to it were being removed regardless of whether the user specified they should


# Changes Made

Created a function that checks whether a token given by string.split() is in the vocab dictionary by using the same regular expression used in the creation of the dictionary to isolate tokens, or if it is all punctuation. Then, rewrite the step where docs filter out words which are not in the vocab dictionary keep the token if it is a word or pure punctuation.

Created a new test to make sure unintended words were not being removed during preprocessing

# Rationale

I assumed that the reason for only keeping the tokens if they were in the vocab set was in order to filter out unwanted words, since there are situations in which it would be appropriate to preserve lone punctuation, such as [word1 - word2]. This is why the new version preserves punctuation as well as vocab words. If the user specifies that punctuation should be removed, that removal happens before this step, so this has no effect on that case.

In order to test and make sure similar removals would not happen, I created my new test.